### PR TITLE
Fix React version in frontend_design.md

### DIFF
--- a/frontend_design.md
+++ b/frontend_design.md
@@ -9,7 +9,7 @@
 
 ### 2.1. 主要技術スタック
 
--   **UIライブラリ**: React (v19)
+-   **UIライブラリ**: React (v19.1)
 -   **言語**: TypeScript
 -   **ルーティング**: React Router DOM (v7)
 -   **スタイリング**: Tailwind CSS (v3)


### PR DESCRIPTION
## Summary
- update React version in docs to match package.json

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684030213598832ea95cf98a3181745e