### PR TITLE
Fix Alembic import for CURRENT_DATABASE_URL

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,4 +1,4 @@
-from backend.app.db import Base, DATABASE_URL as APP_CONFIGURED_DATABASE_URL
+from backend.app.db import Base, CURRENT_DATABASE_URL as APP_CONFIGURED_DATABASE_URL
 from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config


### PR DESCRIPTION
## Summary
- pull CURRENT_DATABASE_URL instead of DATABASE_URL in Alembic env

## Testing
- `alembic upgrade head --sql`
- `pytest -q` *(fails: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_68402ff7e1d8832eb49509b2a8cb7d6c