### PR TITLE
Clarify review router prefix comment

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,20 +20,9 @@ app.include_router(
     books.router, prefix=f"{settings.API_V1_STR}/books", tags=["Books"])
 app.include_router(categories.router, prefix=f"{settings.API_V1_STR}/categories",
                    tags=["Categories"])
-# Prefix handled within reviews.py, so we add API_V1_STR here if reviews.router itself doesn't include /api/v1
-# Assuming reviews.router has its own specific prefix like /books/{book_id}/reviews
-# If reviews.router is meant to be at /api/v1/reviews, then it needs f"{settings.API_V1_STR}/reviews"
-# For now, let's assume reviews.router paths are relative to API_V1_STR if no other prefix is given
-# A common pattern is that sub-routers (like reviews for a book) are mounted under their parent.
-# If reviews.router is a top-level router, it should be:
-# app.include_router(reviews.router, prefix=f"{settings.API_V1_STR}/reviews", tags=["Reviews"])
-# Given the comment "# Prefix handled within reviews.py", it's safer to assume it's a sub-router or its paths are absolute.
-# Let's check reviews.py later if this doesn't fix things. For now, we'll assume it's fine or needs its own API_V1_STR prefix.
-# To be safe and consistent, if reviews.router is a top-level router, it should have the API_V1_STR prefix.
-# If it's a sub-router (e.g. /books/{book_id}/reviews), then the parent router (books) already has the API_V1_STR.
-# Let's assume for now it's a top-level router that needs the prefix.
-app.include_router(reviews.router, prefix=f"{settings.API_V1_STR}", tags=[
-                   "Reviews"])  # Assuming reviews.router has paths like /reviews
+# Reviews endpoints define their own paths (e.g. /books/{book_id}/reviews),
+# so we only prepend API_V1_STR here.
+app.include_router(reviews.router, prefix=f"{settings.API_V1_STR}", tags=["Reviews"])
 app.include_router(
     users.router, prefix=f"{settings.API_V1_STR}/users", tags=["Users"])
 


### PR DESCRIPTION
## Summary
- simplify the comments around the reviews router include

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6840302546dc832ebd835e05bfc4d570