### PR TITLE
Add get_users with pagination

### DIFF
--- a/backend/app/crud/crud_user.py
+++ b/backend/app/crud/crud_user.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Optional
+from typing import Optional, List
 
 from sqlalchemy.orm import Session
 from passlib.context import CryptContext  # For password hashing
@@ -25,6 +25,11 @@ def get_user(db: Session, user_id: uuid.UUID) -> Optional[models.User]:
 
 def get_user_by_email(db: Session, email: str) -> Optional[models.User]:
     return db.query(models.User).filter(models.User.email == email).first()
+
+
+def get_users(db: Session, skip: int = 0, limit: int = 100) -> List[models.User]:
+    """Retrieve a list of users with pagination."""
+    return db.query(models.User).offset(skip).limit(limit).all()
 
 
 def create_user(db: Session, user: schemas.UserCreate) -> models.User:

--- a/backend/tests/crud/test_crud_user.py
+++ b/backend/tests/crud/test_crud_user.py
@@ -91,33 +91,26 @@ def test_get_user_by_email(db_session: Session):
         db=db_session, email="nonexistent@example.com")
     assert non_existent_user is None
 
-# def test_get_users(db_session: Session):
-#     # crud_user.py does not have get_users function
-#     # Arrange
-#     user1 = crud.user.create_user(
-#         db=db_session, user=create_dummy_user_data(email_suffix="_list1"))
-#     user2 = crud.user.create_user(
-#         db=db_session, user=create_dummy_user_data(email_suffix="_list2"))
-#
-#     # Act
-#     # users_skip0_limit10 = crud.user.get_users(db=db_session, skip=0, limit=10) # This function does not exist
-#     # users_skip1_limit1 = crud.user.get_users(db=db_session, skip=1, limit=1)  # This function does not exist
-#     users_skip0_limit10 = [] # Placeholder
-#     users_skip1_limit1 = []  # Placeholder
-#
-#
-#     # Assert
-#     # assert len(users_skip0_limit10) >= 2
-#     # user_ids_skip0_limit10 = [u.id for u in users_skip0_limit10]
-#     # assert user1.id in user_ids_skip0_limit10
-#     # assert user2.id in user_ids_skip0_limit10
-#
-#     # assert len(users_skip1_limit1) == 1
-#     # all_users_sorted = sorted(
-#     #     [user1, user2], key=lambda u: u.id)
-#     # if len(all_users_sorted) > 1 and users_skip1_limit1:
-#     #     assert users_skip1_limit1[0].id == all_users_sorted[1].id
-#     pass
+def test_get_users(db_session: Session):
+    # Arrange
+    user1 = crud.user.create_user(
+        db=db_session, user=create_dummy_user_data(email_suffix="_list1"))
+    user2 = crud.user.create_user(
+        db=db_session, user=create_dummy_user_data(email_suffix="_list2"))
+
+    # Act
+    users_skip0_limit10 = crud.user.get_users(db=db_session, skip=0, limit=10)
+    users_skip1_limit1 = crud.user.get_users(db=db_session, skip=1, limit=1)
+
+    # Assert
+    assert len(users_skip0_limit10) >= 2
+    user_ids_skip0_limit10 = [u.id for u in users_skip0_limit10]
+    assert user1.id in user_ids_skip0_limit10
+    assert user2.id in user_ids_skip0_limit10
+
+    assert len(users_skip1_limit1) == 1
+    if len(users_skip0_limit10) > 1:
+        assert users_skip1_limit1[0].id == users_skip0_limit10[1].id
 
 
 def test_update_user(db_session: Session):


### PR DESCRIPTION
## Summary
- implement `get_users` with basic pagination support
- test user listing behavior

## Testing
- `pytest -q tests/crud/test_crud_user.py::test_get_users`
- `pytest -q tests/crud/test_crud_user.py`

------
https://chatgpt.com/codex/tasks/task_e_68403026b6b8832eaa7433dc80ad160c