### PR TITLE
Fix theme API test

### DIFF
--- a/backend/app/routes/themes.py
+++ b/backend/app/routes/themes.py
@@ -15,8 +15,9 @@ def list_themes(db: Session = Depends(get_db), skip: int = 0, limit: int = 100) 
     result = []
     for theme in themes:
         book_count = len(theme.book_themes)
-        result.append(schemas.ThemeRead.model_validate(
-            theme, context={"book_count": book_count}))
+        # Attach book_count temporarily for Pydantic conversion
+        setattr(theme, "book_count", book_count)
+        result.append(schemas.ThemeRead.model_validate(theme))
     return result
 
 

--- a/backend/tests/api/test_themes.py
+++ b/backend/tests/api/test_themes.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from backend.app.core.config import settings
 from backend.tests.crud.test_crud_theme import create_db_theme
 from backend.tests.crud.test_crud_book import create_dummy_book_for_related_tests
-from backend.app import crud, schemas
+from backend.app import crud, schemas, models
 
 
 def test_list_themes(client: TestClient, db_session: Session) -> None:
@@ -17,7 +17,7 @@ def test_list_themes(client: TestClient, db_session: Session) -> None:
         book_in=schemas.BookUpdate(theme_ids=[theme.id])
     )
     db_session.commit()  # Reverted back to commit()
-
+    # Debugging output removed
     response = client.get(f"{settings.API_V1_STR}/themes")
     assert response.status_code == 200
     data = response.json()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,9 +1,9 @@
-from app.db import get_db  # Import the original get_db dependency
-from app.main import app  # Import your FastAPI app
+from backend.app.db import get_db  # Import the original get_db dependency
+from backend.app.main import app  # Import your FastAPI app
 from fastapi.testclient import TestClient
-from app.models import *
-from app.db import Base  # We still need Base for metadata
-from app.core.config import settings
+from backend.app.models import *
+from backend.app.db import Base  # We still need Base for metadata
+from backend.app.core.config import settings
 from typing import Generator
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy import create_engine


### PR DESCRIPTION
## Summary
- ensure tests use backend imports so overrides match
- temporarily attach `book_count` to theme models before serialization
- adjust API test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405de11e34832ebef9672b86ea0d65