### PR TITLE
Add favorites API endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from .db import get_db, engine, Base  # db.py から import
 from . import models  # Import models to register them with Base
-from .routes import auth, books, themes, reviews, users  # Import routers
+from .routes import auth, books, themes, reviews, users, favorites  # Import routers
 from .core.config import settings  # Import settings for API_V1_STR
 
 app = FastAPI(
@@ -25,6 +25,11 @@ app.include_router(
 app.include_router(reviews.router, prefix=f"{settings.API_V1_STR}", tags=["Reviews"])
 app.include_router(
     users.router, prefix=f"{settings.API_V1_STR}/users", tags=["Users"])
+app.include_router(
+    favorites.router,
+    prefix=f"{settings.API_V1_STR}",
+    tags=["Favorites"],
+)
 
 
 # ── 開発中だけ: 起動時にテーブル作成しておく ──

--- a/backend/app/routes/favorites.py
+++ b/backend/app/routes/favorites.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from fastapi import Response
+import uuid
+
+from backend.app import schemas, models
+from backend.app.crud import crud_favorite, crud_book
+from backend.app.core.security import get_current_user
+from backend.app.db import get_db
+
+router = APIRouter()
+
+
+@router.get("/users/me/favorites", response_model=list[schemas.BookRead])
+def list_favorites(
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+    skip: int = 0,
+    limit: int = 100,
+) -> list[schemas.BookRead]:
+    books = crud_favorite.get_user_favorites(
+        db, user_id=current_user.id, skip=skip, limit=limit
+    )
+    return books
+
+
+@router.post("/users/me/favorites/{book_id}", response_model=schemas.Msg)
+def add_favorite(
+    book_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> schemas.Msg:
+    db_book = crud_book.get_book(db, book_id=book_id)
+    if not db_book:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found")
+
+    crud_favorite.add_favorite(db, user_id=current_user.id, book_id=book_id)
+    db.commit()
+    return {"message": "Book added to favorites"}
+
+
+@router.delete("/users/me/favorites/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remove_favorite(
+    book_id: uuid.UUID,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    fav = crud_favorite.remove_favorite(db, user_id=current_user.id, book_id=book_id)
+    if not fav:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Favorite not found")
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/api/test_favorites.py
+++ b/backend/tests/api/test_favorites.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from backend.app.core.config import settings
+from backend.tests.api.test_users import get_auth_headers
+from backend.tests.crud.test_crud_book import create_dummy_book_for_related_tests
+
+
+def test_add_and_list_favorites(client: TestClient, db_session: Session) -> None:
+    email = "favuser@example.com"
+    password = "FavPass123"
+    name = "Fav User"
+    headers = get_auth_headers(client, email, password, name)
+
+    book = create_dummy_book_for_related_tests(db_session, title_suffix="_fav")
+    db_session.commit()
+
+    resp = client.post(
+        f"{settings.API_V1_STR}/users/me/favorites/{book.id}", headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["message"] == "Book added to favorites"
+
+    list_resp = client.get(
+        f"{settings.API_V1_STR}/users/me/favorites", headers=headers
+    )
+    assert list_resp.status_code == 200
+    data = list_resp.json()
+    assert len(data) == 1
+    assert data[0]["id"] == str(book.id)
+
+
+def test_remove_favorite(client: TestClient, db_session: Session) -> None:
+    email = "favdel@example.com"
+    password = "FavDel123"
+    name = "Fav Del"
+    headers = get_auth_headers(client, email, password, name)
+
+    book = create_dummy_book_for_related_tests(db_session, title_suffix="_del")
+    db_session.commit()
+
+    client.post(
+        f"{settings.API_V1_STR}/users/me/favorites/{book.id}", headers=headers
+    )
+    del_resp = client.delete(
+        f"{settings.API_V1_STR}/users/me/favorites/{book.id}", headers=headers
+    )
+    assert del_resp.status_code == 204
+
+    list_resp = client.get(
+        f"{settings.API_V1_STR}/users/me/favorites", headers=headers
+    )
+    assert list_resp.status_code == 200
+    assert list_resp.json() == []


### PR DESCRIPTION
## Summary
- implement GET/POST/DELETE /users/me/favorites routes
- hook favorites router into FastAPI app
- add API tests for favorites feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684068e30264832e86f4e920754acc2e