### PR TITLE
Integrate frontend with backend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,6 +9,10 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create a `.env` file with the API base URL:
+   ```
+   VITE_API_BASE_URL=http://localhost:8000/api/v1
+   ```
+   You can also set `GEMINI_API_KEY` here if needed.
 3. Run the app:
    `npm run dev`

--- a/frontend/api.ts
+++ b/frontend/api.ts
@@ -1,0 +1,14 @@
+export async function api<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = localStorage.getItem('authToken');
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options.headers || {}) as Record<string, string>
+  };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}${path}`, {
+    ...options,
+    headers
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json() as Promise<T>;
+}

--- a/frontend/hooks/useAuth.tsx
+++ b/frontend/hooks/useAuth.tsx
@@ -1,24 +1,18 @@
 
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { User } from '../types'; // Ensure this path is correct
+import { User } from '../types';
+import { api } from '../api';
 
 interface AuthContextType {
   isAuthenticated: boolean;
   user: User | null;
-  login: (email: string, pass: string) => Promise<void>; // Changed to Promise for async simulation
+  login: (email: string, pass: string) => Promise<void>;
   logout: () => void;
   loading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-const MOCK_USER: User = {
-  id: 'user123',
-  name: '哲学者キッズ',
-  email: 'test@example.com',
-  avatarUrl: 'https://picsum.photos/seed/user123/100/100',
-  tier: 'Premium',
-};
 
 export const AuthProvider: React.FC<{children: React.ReactNode}> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
@@ -35,25 +29,27 @@ export const AuthProvider: React.FC<{children: React.ReactNode}> = ({ children }
 
   const login = useCallback(async (email: string, pass: string): Promise<void> => {
     setLoading(true);
-    // Simulate API call
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        if (email === 'test@example.com' && pass === 'password') {
-          localStorage.setItem('authUser', JSON.stringify(MOCK_USER));
-          setUser(MOCK_USER);
-          setLoading(false);
-          resolve();
-        } else {
-          setLoading(false);
-          reject(new Error('Invalid credentials'));
+    try {
+      const data = await api<{ access_token: string; user: User }>(
+        '/auth/login',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ username: email, password: pass })
         }
-      }, 1000);
-    });
+      );
+      localStorage.setItem('authToken', data.access_token);
+      localStorage.setItem('authUser', JSON.stringify(data.user));
+      setUser(data.user);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   const logout = useCallback(() => {
     setLoading(true);
     localStorage.removeItem('authUser');
+    localStorage.removeItem('authToken');
     setUser(null);
     setLoading(false);
   }, []);

--- a/frontend/hooks/useBooks.ts
+++ b/frontend/hooks/useBooks.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { Book } from '../types';
+import { api } from '../api';
+
+export function useBooks() {
+  const [books, setBooks] = useState<Book[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchBooks() {
+      try {
+        const data = await api<Book[]>('/books');
+        setBooks(data);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchBooks();
+  }, []);
+
+  return { books, loading };
+}

--- a/frontend/hooks/useThemes.ts
+++ b/frontend/hooks/useThemes.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import { PhilosophyTheme } from '../types';
+import { api } from '../api';
+
+export function useThemes() {
+  const [themes, setThemes] = useState<PhilosophyTheme[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchThemes() {
+      try {
+        const data = await api<PhilosophyTheme[]>('/themes');
+        setThemes(data);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchThemes();
+  }, []);
+
+  return { themes, loading };
+}

--- a/frontend/pages/BooksPage.tsx
+++ b/frontend/pages/BooksPage.tsx
@@ -6,12 +6,15 @@ import FilterAndSortSection from '../components/books_page/FilterAndSortSection'
 import BookListArea from '../components/books_page/BookListArea';
 import PaginationControls from '../components/ui/PaginationControls';
 import { Book, BookFilters, BookSortOption, BookTypeFilterOption, PhilosophyTheme } from '../types';
-import { MOCK_BOOKS, MOCK_THEMES, ITEMS_PER_PAGE } from '../constants';
+import { ITEMS_PER_PAGE } from '../constants';
+import { useBooks } from '../hooks/useBooks';
+import { useThemes } from '../hooks/useThemes';
 import { useFavorites } from '../hooks/useFavorites'; // Import useFavorites
 
 const BooksPage: React.FC = () => {
-  const [allBooks] = useState<Book[]>(MOCK_BOOKS);
-  const [filteredBooks, setFilteredBooks] = useState<Book[]>(allBooks);
+  const { books: allBooks, loading: booksLoading } = useBooks();
+  const { themes } = useThemes();
+  const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
   const [displayedBooks, setDisplayedBooks] = useState<Book[]>([]);
   
   const [filters, setFilters] = useState<BookFilters>({
@@ -55,10 +58,8 @@ const BooksPage: React.FC = () => {
     }
 
     if (filters.themeId) {
-        const selectedTheme = MOCK_THEMES.find(t => t.id === filters.themeId);
+        const selectedTheme = themes.find(t => t.id === filters.themeId);
         if (selectedTheme) {
-             // Filter books whose tags include the selected theme's name
-             // This is a simplification; a real app might have a direct theme_id on books or a join table.
             books = books.filter(book => book.tags?.some(tag => tag.toLowerCase().includes(selectedTheme.name.toLowerCase())));
         }
     }
@@ -105,10 +106,9 @@ const BooksPage: React.FC = () => {
     }
 
     setFilteredBooks(books);
-    setCurrentPage(1); 
-    // Simulate API delay
-    setTimeout(() => setIsLoading(false), 300);
-  }, [allBooks, filters, sortOption]);
+    setCurrentPage(1);
+    setIsLoading(false);
+  }, [allBooks, filters, sortOption, themes]);
 
   useEffect(() => {
     applyFiltersAndSort();
@@ -156,7 +156,7 @@ const BooksPage: React.FC = () => {
           />
           <BookListArea 
             books={displayedBooks} 
-            isLoading={isLoading || favoritesLoading} // Consider favorites loading state
+            isLoading={isLoading || favoritesLoading || booksLoading}
             onFavoriteToggle={toggleFavorite}
             favorites={favorites}
           />

--- a/frontend_backend_integration_plan.md
+++ b/frontend_backend_integration_plan.md
@@ -5,7 +5,7 @@ This document outlines how to connect the existing React frontend with the FastA
 ## 1. Overview
 - **Backend**: FastAPI application located in `backend/` with routers for auth, books, themes, reviews, favorites, children, progress, user settings, and learning history.
 - **Database**: PostgreSQL. Connection settings are loaded from environment variables in `backend/.env`.
-- **Frontend**: React + Vite project located in `frontend/`. Currently uses mock data and localStorage based state.
+- **Frontend**: React + Vite project located in `frontend/`. Books, themes and authentication now call the FastAPI backend. Other features still rely on mock data and localStorage for now.
 
 ## 2. Environment Setup
 1. Install PostgreSQL and create two databases: one for development and one for tests.
@@ -25,6 +25,8 @@ This document outlines how to connect the existing React frontend with the FastA
    ```bash
    cd frontend
    npm install
+   # create .env with the API base URL
+   echo "VITE_API_BASE_URL=http://localhost:8000/api/v1" > .env
    npm run dev
    ```
 
@@ -80,3 +82,13 @@ Integration can proceed page by page to minimize breakage.
 - Frontend can use React Testing Library or similar if needed.
 
 This plan should help transition from mock data to live API communication and ensure both sides work together smoothly.
+
+## 8. Current Status
+- Implemented `api` helper and hooks (`useBooks`, `useThemes`) for making authenticated requests.
+- Updated `useAuth` to perform real login against the backend.
+- Books list and theme book pages now load data from the FastAPI API.
+
+## 9. Remaining Tasks
+- Migrate favorites, children management, reviews, reading progress, and settings pages to use API endpoints.
+- Add user registration and token refresh handling.
+- Write frontend tests where appropriate.


### PR DESCRIPTION
## Summary
- add API helper and hooks for books and themes
- call FastAPI backend for auth and book/theme data
- document API base URL for the frontend
- remove mock data usage
- document integration progress

## Testing
- `npm install`
- `pytest -q` *(fails: TEST_DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_684119854554832e8f96341adcde53d9