### PR TITLE
Implement favorites and children API integration

### DIFF
--- a/HOW_TO_RUN_TESTS.md
+++ b/HOW_TO_RUN_TESTS.md
@@ -46,11 +46,20 @@ SECRET_KEY=your_secret_key
 
 ## 3. テストの実行
 
-テストは `backend` ディレクトリで実行します。ディレクトリを移動して `pytest` を実行してください。
+テスト用の `.env` は `backend/.env` に配置します。`backend/app/core/config.py` が
+自動的にこのファイルを読み込むため、`pytest` をどのディレクトリから実行しても設定が適用されます。
+
+テストは `backend` ディレクトリで実行するのが簡単ですが、プロジェクトルートからでも `TESTING=true` を指定して実行できます。
 
 ```bash
 cd backend
 pytest
+```
+
+または
+
+```bash
+TESTING=true pytest -q backend
 ```
 
 `pytest` コマンドを実行すると、`backend/tests` 以下のテストが自動的に収集されます。  

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -23,11 +24,13 @@ class Settings(BaseSettings):
     # Environment mode
     TESTING: bool = False  # Can be overridden by .env e.g. TESTING=true
 
+    BASE_DIR: Path = Path(__file__).resolve().parents[2]
+
     model_config = SettingsConfigDict(
-        # Assumes .env is in the CWD (e.g., backend/ when running pytest from backend/)
-        env_file=".env",
+        # Load environment variables from backend/.env regardless of CWD
+        env_file=BASE_DIR / ".env",
         extra='ignore',
-        case_sensitive=False
+        case_sensitive=False,
     )
 
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -18,6 +18,7 @@ import QuestionAnswerPage from './pages/QuestionAnswerPage'; // Import QuestionA
 import NotFoundPage from './pages/NotFoundPage';
 import { AuthProvider, useAuth } from './hooks/useAuth'; 
 import { FavoritesProvider } from './hooks/useFavorites';
+import { ChildrenProvider } from './hooks/useChildren';
 import { RoutePath } from './types';
 
 // Settings Page Imports
@@ -55,8 +56,9 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
 const App: React.FC = () => {
   return (
     <AuthProvider>
-      <FavoritesProvider> 
-        <HashRouter>
+      <FavoritesProvider>
+        <ChildrenProvider>
+          <HashRouter>
           <Routes>
             {/* Public Routes */}
             <Route path={RoutePath.Login} element={<LoginPage />} />
@@ -144,7 +146,8 @@ const App: React.FC = () => {
             />
             <Route path="*" element={<NotFoundPage />} />
           </Routes>
-        </HashRouter>
+          </HashRouter>
+        </ChildrenProvider>
       </FavoritesProvider>
     </AuthProvider>
   );

--- a/frontend/components/auth/RegistrationForm.tsx
+++ b/frontend/components/auth/RegistrationForm.tsx
@@ -6,6 +6,7 @@ import Button from '../ui/Button';
 import { RoutePath } from '../../types';
 import { UserCircleIcon, EnvelopeIcon, LockClosedIcon as PasswordIcon, AcademicCapIcon, IdentificationIcon, CakeIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import Card, { CardHeader, CardContent, CardFooter } from '../ui/Card';
+import { api } from '../../api';
 
 type UserType = 'parent' | 'teacher';
 
@@ -79,20 +80,24 @@ const RegistrationForm: React.FC = () => {
     if (!validate()) return;
 
     setLoading(true);
-    console.log('Registration Data:', {
-      userType,
+    const payload = {
       name,
       email,
       password,
-      children: userType === 'parent' ? childrenInfo.map(c => ({...c, age: parseInt(c.age, 10)})) : [],
-      termsAccepted,
-    });
-
-    setTimeout(() => {
-      setLoading(false);
+    };
+    try {
+      await api('/auth/register', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
       alert('会員登録が完了しました！ログインページに移動します。');
       navigate(RoutePath.Login);
-    }, 1500);
+    } catch (error) {
+      console.error('Registration failed:', error);
+      alert('登録に失敗しました');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (

--- a/frontend/components/settings/AddChildForm.tsx
+++ b/frontend/components/settings/AddChildForm.tsx
@@ -5,6 +5,7 @@ import Button from '../ui/Button';
 import Avatar from '../ui/Avatar';
 import { RoutePath } from '../../types';
 import { UserCircleIcon, CakeIcon, PhotoIcon, SparklesIcon, ArrowUpTrayIcon } from '../../assets/icons';
+import { useChildren } from '../../hooks/useChildren';
 
 const MOCK_AVATARS = [
   'https://picsum.photos/seed/avatar1/100/100',
@@ -25,6 +26,7 @@ const AddChildForm: React.FC = () => {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
+  const { addChild } = useChildren();
 
   const handleAvatarFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
@@ -65,13 +67,15 @@ const AddChildForm: React.FC = () => {
       interests: interests.split(',').map(interest => interest.trim()).filter(i => i),
     };
 
-    console.log('Adding child:', childData);
-    // Simulate API call
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    alert(`${name}ちゃん・くんの情報を追加しました (モック)。`);
-    setIsSubmitting(false);
-    navigate(RoutePath.ChildrenManage);
+    try {
+      await addChild(childData);
+      navigate(RoutePath.ChildrenManage);
+    } catch (error) {
+      console.error('Failed to add child:', error);
+      alert('お子様の追加に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (

--- a/frontend/components/settings/EditChildForm.tsx
+++ b/frontend/components/settings/EditChildForm.tsx
@@ -5,6 +5,7 @@ import Button from '../ui/Button';
 import Avatar from '../ui/Avatar';
 import { RoutePath, Child } from '../../types';
 import { UserCircleIcon, CakeIcon, PhotoIcon, SparklesIcon, ArrowUpTrayIcon } from '../../assets/icons';
+import { useChildren } from '../../hooks/useChildren';
 
 const MOCK_AVATARS = [ // Should be in constants, but for simplicity here
   'https://picsum.photos/seed/avatar1/100/100',
@@ -29,6 +30,7 @@ const EditChildForm: React.FC<EditChildFormProps> = ({ child }) => {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
+  const { updateChild } = useChildren();
 
   useEffect(() => {
     setName(child.name);
@@ -71,20 +73,21 @@ const EditChildForm: React.FC<EditChildFormProps> = ({ child }) => {
 
     setIsSubmitting(true);
     const updatedChildData = {
-      id: child.id,
       name,
       age: parseInt(age, 10),
       avatarUrl: avatarFile ? `local_file_preview_for_${avatarFile.name}` : avatarUrl,
       interests: interests.split(',').map(interest => interest.trim()).filter(i => i),
     };
 
-    console.log('Updating child:', updatedChildData);
-    // Simulate API call
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    alert(`${name}ちゃん・くんの情報を更新しました (モック)。`);
-    setIsSubmitting(false);
-    navigate(RoutePath.ChildrenManage);
+    try {
+      await updateChild(child.id, updatedChildData);
+      navigate(RoutePath.ChildrenManage);
+    } catch (error) {
+      console.error('Failed to update child:', error);
+      alert('お子様の情報更新に失敗しました');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (

--- a/frontend/hooks/useChildren.tsx
+++ b/frontend/hooks/useChildren.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useCallback, useContext, useEffect, useState, ReactNode } from 'react';
+import { api } from '../api';
+import { Child } from '../types';
+
+interface ChildrenContextType {
+  children: Child[];
+  loading: boolean;
+  refreshChildren: () => Promise<void>;
+  addChild: (child: Omit<Child, 'id'>) => Promise<void>;
+  updateChild: (id: string, child: Partial<Child>) => Promise<void>;
+  deleteChild: (id: string) => Promise<void>;
+}
+
+const ChildrenContext = createContext<ChildrenContextType | undefined>(undefined);
+
+export const ChildrenProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [childList, setChildList] = useState<Child[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refreshChildren = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api<Child[]>('/users/me/children');
+      setChildList(data);
+    } catch (err) {
+      console.error('Failed to fetch children:', err);
+      setChildList([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshChildren();
+  }, [refreshChildren]);
+
+  const addChild = useCallback(async (child: Omit<Child, 'id'>) => {
+    const newChild = await api<Child>('/users/me/children', {
+      method: 'POST',
+      body: JSON.stringify(child)
+    });
+    setChildList(prev => [...prev, newChild]);
+  }, []);
+
+  const updateChild = useCallback(async (id: string, child: Partial<Child>) => {
+    const updated = await api<Child>(`/users/me/children/${id}`, {
+      method: 'PUT',
+      body: JSON.stringify(child)
+    });
+    setChildList(prev => prev.map(c => c.id === id ? updated : c));
+  }, []);
+
+  const deleteChild = useCallback(async (id: string) => {
+    await api(`/users/me/children/${id}`, { method: 'DELETE' });
+    setChildList(prev => prev.filter(c => c.id !== id));
+  }, []);
+
+  return (
+    <ChildrenContext.Provider value={{ children: childList, loading, refreshChildren, addChild, updateChild, deleteChild }}>
+      {children}
+    </ChildrenContext.Provider>
+  );
+};
+
+export const useChildren = (): ChildrenContextType => {
+  const ctx = useContext(ChildrenContext);
+  if (!ctx) throw new Error('useChildren must be used within a ChildrenProvider');
+  return ctx;
+};

--- a/frontend/pages/FavoritesPage.tsx
+++ b/frontend/pages/FavoritesPage.tsx
@@ -6,8 +6,9 @@ import FilterAndSortSection from '../components/favorites_page/FilterAndSortSect
 import BookListArea from '../components/books_page/BookListArea';
 import PaginationControls from '../components/ui/PaginationControls';
 import { Book, BookFilters, BookSortOption, BookTypeFilterOption } from '../types';
-import { MOCK_BOOKS, ITEMS_PER_PAGE } from '../constants';
+import { ITEMS_PER_PAGE } from '../constants';
 import { useFavorites } from '../hooks/useFavorites';
+import { api } from '../api';
 import { Link } from 'react-router-dom';
 import { RoutePath } from '../types';
 import Button from '../components/ui/Button';
@@ -32,10 +33,16 @@ const FavoritesPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    setIsLoading(true);
-    const favoriteBookDetails = MOCK_BOOKS.filter(book => favorites.has(book.id));
-    setAllFavoriteBooks(favoriteBookDetails);
-    // Initial filtering/sorting will be triggered by the next useEffect
+    async function fetchFavorites() {
+      setIsLoading(true);
+      try {
+        const data = await api<Book[]>("/users/me/favorites");
+        setAllFavoriteBooks(data);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchFavorites();
   }, [favorites]);
 
   const parseAgeRange = (ageRangeString: string): [number, number] | null => {

--- a/frontend/pages/settings/ChildDetailPage.tsx
+++ b/frontend/pages/settings/ChildDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Child, RoutePath } from '../../types';
-import { MOCK_CHILDREN } from '../../constants'; // Assuming MOCK_CHILDREN is available
+import { useChildren } from '../../hooks/useChildren';
 import ChildDetailContent from '../../components/settings/ChildDetailContent';
 import Button from '../../components/ui/Button';
 import { ArrowUturnLeftIcon } from '../../assets/icons';
@@ -9,16 +9,15 @@ import { ArrowUturnLeftIcon } from '../../assets/icons';
 const ChildDetailPage: React.FC = () => {
   const { id: childId } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { children, loading } = useChildren();
   const [child, setChild] = useState<Child | null>(null);
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (childId) {
-      const foundChild = MOCK_CHILDREN.find(c => c.id === childId);
-      setChild(foundChild || null);
+      const found = children.find(c => c.id === childId);
+      setChild(found || null);
     }
-    setLoading(false);
-  }, [childId]);
+  }, [childId, children]);
 
   if (loading) {
     return <div className="text-center py-10">お子様の情報を読み込み中...</div>;

--- a/frontend/pages/settings/ChildrenManagementPage.tsx
+++ b/frontend/pages/settings/ChildrenManagementPage.tsx
@@ -1,25 +1,27 @@
 import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { MOCK_CHILDREN } from '../../constants'; // Using existing mock children
-import { Child, RoutePath } from '../../types';
+import { RoutePath } from '../../types';
 import ChildManagementCard from '../../components/settings/ChildManagementCard';
 import Button from '../../components/ui/Button';
 import { PlusCircleIcon, IdentificationIcon } from '../../assets/icons';
+import { useChildren } from '../../hooks/useChildren';
 
 const ChildrenManagementPage: React.FC = () => {
   const navigate = useNavigate();
-  // In a real app, children would come from useAuth context or an API call
-  const children: Child[] = MOCK_CHILDREN; 
+  const { children, deleteChild, loading } = useChildren();
 
   const handleAddChild = () => {
     navigate(RoutePath.ChildAdd);
   };
 
-  const handleDeleteChild = (childId: string) => {
-    if (window.confirm("本当にこのお子様の情報を削除しますか？この操作は元に戻せません。")) {
-      console.log(`Deleting child with ID: ${childId}`);
-      // Add logic to update state/API
-      alert("お子様の情報が削除されました (モック)。");
+  const handleDeleteChild = async (childId: string) => {
+    if (window.confirm('本当にこのお子様の情報を削除しますか？この操作は元に戻せません。')) {
+      try {
+        await deleteChild(childId);
+      } catch (err) {
+        console.error('Failed to delete child:', err);
+        alert('削除に失敗しました');
+      }
     }
   };
 
@@ -39,13 +41,17 @@ const ChildrenManagementPage: React.FC = () => {
         </Button>
       </div>
 
-      {children.length > 0 ? (
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <div className="w-12 h-12 border-4 border-amber-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : children.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {children.map((child) => (
-            <ChildManagementCard 
-              key={child.id} 
-              child={child} 
-              onDelete={() => handleDeleteChild(child.id)} 
+            <ChildManagementCard
+              key={child.id}
+              child={child}
+              onDelete={() => handleDeleteChild(child.id)}
             />
           ))}
         </div>

--- a/frontend/pages/settings/EditChildPage.tsx
+++ b/frontend/pages/settings/EditChildPage.tsx
@@ -3,22 +3,21 @@ import { useNavigate, useParams } from 'react-router-dom';
 import EditChildForm from '../../components/settings/EditChildForm';
 import Button from '../../components/ui/Button';
 import { RoutePath, Child } from '../../types';
-import { MOCK_CHILDREN } from '../../constants';
+import { useChildren } from '../../hooks/useChildren';
 import { ArrowUturnLeftIcon } from '../../assets/icons';
 
 const EditChildPage: React.FC = () => {
   const navigate = useNavigate();
   const { id: childId } = useParams<{ id: string }>();
+  const { children, loading } = useChildren();
   const [childToEdit, setChildToEdit] = useState<Child | null>(null);
-  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (childId) {
-      const foundChild = MOCK_CHILDREN.find(c => c.id === childId);
-      setChildToEdit(foundChild || null);
+      const found = children.find(c => c.id === childId);
+      setChildToEdit(found || null);
     }
-    setLoading(false);
-  }, [childId]);
+  }, [childId, children]);
 
   if (loading) {
     return <div className="text-center py-10">お子様の情報を読み込み中...</div>;

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -10,13 +10,13 @@ export interface User {
 }
 
 export interface Child {
-  id:string;
+  id: string;
   name: string;
   age: number;
   avatarUrl?: string;
-  progress: number; // 0-100
-  recentActivity: string;
   interests?: string[];
+  progress?: number; // 0-100
+  recentActivity?: string;
 }
 
 export type ThemeCategory = 'all' | 'self' | 'others' | 'world' | 'thinking';


### PR DESCRIPTION
## Summary
- connect favorites to FastAPI using `useFavorites`
- add `useChildren` provider and migrate child pages to API
- register users with `/auth/register`
- fetch favorite books from API
- update `Child` type definition
- load backend config from `backend/.env`
- document how to run pytest from any directory

## Testing
- `pip install -r requirements.txt`
- `TESTING=true pytest -q`
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684127ea5e6c832e8127eda0b40afee5