### PR TITLE
Update docs for correct uvicorn path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ Execute the following steps from the project root unless otherwise noted.
    pip install -r requirements.txt
    ```
 4. Prepare `backend/.env` with database URLs and a `SECRET_KEY` as described in `HOW_TO_RUN_TESTS.md`.
-5. Start the API server from the `backend` directory:
+5. Start the API server from the project root:
    ```bash
-   cd backend
-   uvicorn app.main:app --reload
+   uvicorn backend.app.main:app --reload
    ```
 
 See `HOW_TO_RUN_TESTS.md` for information on running the automated tests.

--- a/frontend_backend_integration_plan.md
+++ b/frontend_backend_integration_plan.md
@@ -18,8 +18,7 @@ This document outlines how to connect the existing React frontend with the FastA
 3. Install Python dependencies and start the API:
    ```bash
    pip install -r requirements.txt
-   cd backend
-   uvicorn app.main:app --reload
+   uvicorn backend.app.main:app --reload
    ```
 4. In another terminal, install frontend dependencies and run the React app:
    ```bash


### PR DESCRIPTION
## Summary
- clarify that the backend must be launched from the repo root
- fix integration guide to use `uvicorn backend.app.main:app`

## Testing
- `uvicorn backend.app.main:app --reload` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68415725e298832ea509a35d59975289