### PR TITLE
Switch frontend to API data

### DIFF
--- a/frontend/components/books_page/FilterAndSortSection.tsx
+++ b/frontend/components/books_page/FilterAndSortSection.tsx
@@ -3,7 +3,8 @@ import Input from '../ui/Input';
 import Select from '../ui/Select';
 import Button from '../ui/Button';
 import { BookFilters, BookSortOption, PhilosophyTheme, SelectOption, BookTypeFilterOption } from '../../types';
-import { MOCK_THEMES, BOOK_SORT_OPTIONS, BOOK_TYPE_FILTER_OPTIONS } from '../../constants';
+import { BOOK_SORT_OPTIONS, BOOK_TYPE_FILTER_OPTIONS } from '../../constants';
+import { useThemes } from '../../hooks/useThemes';
 import { SearchIcon, FilterIcon, AdjustmentsHorizontalIcon, SparklesIcon } from '../../assets/icons';
 
 interface FilterAndSortSectionProps {
@@ -21,9 +22,10 @@ const FilterAndSortSection: React.FC<FilterAndSortSectionProps> = ({
   onSortChange,
   onResetFilters,
 }) => {
+  const { themes } = useThemes();
   const themeOptions: SelectOption[] = [
     { value: '', label: 'すべてのテーマ' },
-    ...MOCK_THEMES.map(theme => ({ value: theme.id, label: theme.name })),
+    ...themes.map(theme => ({ value: theme.id, label: theme.name })),
   ];
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {

--- a/frontend/components/dashboard/PhilosophyThemesSection.tsx
+++ b/frontend/components/dashboard/PhilosophyThemesSection.tsx
@@ -1,13 +1,13 @@
 
 import React from 'react';
-import { MOCK_THEMES } from '../../constants';
+import { useThemes } from '../../hooks/useThemes';
 import ThemeCard from './ThemeCard';
 import Button from '../ui/Button';
 import { Link } from 'react-router-dom';
 import { RoutePath } from '../../types';
 
 const PhilosophyThemesSection: React.FC = () => {
-  const themes = MOCK_THEMES; 
+  const { themes, loading } = useThemes();
 
   return (
     <section className="mb-8">
@@ -19,9 +19,13 @@ const PhilosophyThemesSection: React.FC = () => {
       </div>
       <div className="flex overflow-x-auto [-ms-scrollbar-style:none] [scrollbar-width:none] [&amp;::-webkit-scrollbar]:hidden pb-4">
         <div className="flex items-stretch p-4 gap-6"> {/* p-4 to give cards space from edge when scrolling */}
-          {themes.map((theme) => (
-            <ThemeCard key={theme.id} theme={theme} />
-          ))}
+          {loading
+            ? [...Array(3)].map((_, i) => (
+                <div key={i} className="w-40 h-48 bg-amber-100 rounded-xl animate-pulse" />
+              ))
+            : themes.map((theme) => (
+                <ThemeCard key={theme.id} theme={theme} />
+              ))}
         </div>
       </div>
     </section>

--- a/frontend/components/dashboard/RecommendedBooksSection.tsx
+++ b/frontend/components/dashboard/RecommendedBooksSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { MOCK_BOOKS } from '../../constants';
+import { useBooks } from '../../hooks/useBooks';
 import BookCard from '../books/BookCard';
 import Button from '../ui/Button';
 import { Link } from 'react-router-dom';
@@ -8,15 +8,16 @@ import { useFavorites } from '../../hooks/useFavorites'; // Import useFavorites
 
 const RecommendedBooksSection: React.FC = () => {
   const [recommendedBooks, setRecommendedBooks] = useState<Book[]>([]);
+  const { books, loading: booksLoading } = useBooks();
   const { favorites, toggleFavorite, loading: favoritesLoading } = useFavorites();
 
   useEffect(() => {
-    // Simulate fetching recommended books - here we just take a slice
-    // In a real app, this might be an API call
-    setRecommendedBooks(MOCK_BOOKS.sort((a,b) => (b.popularityScore || 0) - (a.popularityScore || 0)).slice(0, 4));
-  }, []);
+    if (!booksLoading) {
+      setRecommendedBooks(books.sort((a,b) => (b.popularityScore || 0) - (a.popularityScore || 0)).slice(0, 4));
+    }
+  }, [books, booksLoading]);
 
-  if (favoritesLoading && recommendedBooks.length === 0) { // Show loading only if books aren't ready
+  if ((favoritesLoading || booksLoading) && recommendedBooks.length === 0) { // Show loading only if books aren't ready
     return (
       <section className="mb-8 px-4">
         <div className="flex justify-between items-center pb-4 pt-2">

--- a/frontend/components/favorites_page/FilterAndSortSection.tsx
+++ b/frontend/components/favorites_page/FilterAndSortSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Select from '../ui/Select';
 import { BookFilters, BookSortOption, SelectOption } from '../../types';
-import { MOCK_THEMES } from '../../constants'; // For theme filter options
+import { useThemes } from '../../hooks/useThemes'; // Fetch themes from API
 import { SparklesIcon } from '../../assets/icons';
 
 interface FavoritesFilterAndSortProps {
@@ -19,9 +19,10 @@ const FilterAndSortSection: React.FC<FavoritesFilterAndSortProps> = ({
   onSortChange,
   totalItems,
 }) => {
+  const { themes } = useThemes();
   const themeOptions: SelectOption[] = [
     { value: '', label: 'すべてのテーマ' },
-    ...MOCK_THEMES.map(theme => ({ value: theme.id, label: theme.name })),
+    ...themes.map(theme => ({ value: theme.id, label: theme.name })),
   ];
 
   const sortOptions: SelectOption[] = [

--- a/frontend/pages/SearchPage.tsx
+++ b/frontend/pages/SearchPage.tsx
@@ -7,7 +7,9 @@ import FilterAndSortSection from '../components/books_page/FilterAndSortSection'
 import BookListArea from '../components/books_page/BookListArea';
 import PaginationControls from '../components/ui/PaginationControls';
 import { Book, BookFilters, BookSortOption, RoutePath, BookTypeFilterOption } from '../types';
-import { MOCK_BOOKS, MOCK_THEMES, ITEMS_PER_PAGE } from '../constants';
+import { ITEMS_PER_PAGE } from '../constants';
+import { useBooks } from '../hooks/useBooks';
+import { useThemes } from '../hooks/useThemes';
 import { useFavorites } from '../hooks/useFavorites';
 
 const SearchPage: React.FC = () => {
@@ -15,7 +17,8 @@ const SearchPage: React.FC = () => {
   const query = searchParams.get('q') || '';
   const { favorites, toggleFavorite, loading: favoritesLoading } = useFavorites();
 
-  const [allBooks] = useState<Book[]>(MOCK_BOOKS); // Assuming search is across all books
+  const { books: allBooks, loading: booksLoading } = useBooks();
+  const { themes } = useThemes();
   const [searchedBooks, setSearchedBooks] = useState<Book[]>([]);
   const [filteredBooks, setFilteredBooks] = useState<Book[]>([]);
   const [displayedBooks, setDisplayedBooks] = useState<Book[]>([]);
@@ -29,7 +32,7 @@ const SearchPage: React.FC = () => {
   });
   const [sortOption, setSortOption] = useState<BookSortOption>(BookSortOption.Recommended);
   const [currentPage, setCurrentPage] = useState(1);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   
   // Update filters.searchQuery if URL query changes
   useEffect(() => {
@@ -61,7 +64,7 @@ const SearchPage: React.FC = () => {
 
     // Apply additional filters from FilterAndSortSection
     if (filters.themeId) {
-        const selectedTheme = MOCK_THEMES.find(t => t.id === filters.themeId);
+        const selectedTheme = themes.find(t => t.id === filters.themeId);
         if (selectedTheme) {
             books = books.filter(book => book.tags?.some(tag => tag.toLowerCase().includes(selectedTheme.name.toLowerCase())));
         }
@@ -103,11 +106,13 @@ const SearchPage: React.FC = () => {
     setFilteredBooks(books);
     setCurrentPage(1);
     setTimeout(() => setIsLoading(false), 300);
-  }, [allBooks, filters, sortOption]);
+  }, [allBooks, themes, filters, sortOption]);
 
   useEffect(() => {
-    performSearchAndFilter();
-  }, [performSearchAndFilter]);
+    if (!booksLoading) {
+      performSearchAndFilter();
+    }
+  }, [performSearchAndFilter, booksLoading]);
 
   useEffect(() => {
     const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;

--- a/frontend/pages/ThemesPage.tsx
+++ b/frontend/pages/ThemesPage.tsx
@@ -1,30 +1,22 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import PageHeroSection from '../components/themes_page/PageHeroSection';
 import ThemeCategoryNavigation from '../components/themes_page/ThemeCategoryNavigation';
 import ThemeGridArea from '../components/themes_page/ThemeGridArea';
-import { PhilosophyTheme, ThemeCategory } from '../types';
-import { MOCK_THEMES }  from '../constants';
+import { ThemeCategory } from '../types';
+import { useThemes } from '../hooks/useThemes';
 
 const ThemesPage: React.FC = () => {
-  const [allThemes] = useState<PhilosophyTheme[]>(MOCK_THEMES);
+  const { themes, loading } = useThemes();
   const [selectedCategory, setSelectedCategory] = useState<ThemeCategory>('all');
-  const [isLoading, setIsLoading] = useState(false);
 
   const filteredThemes = useMemo(() => {
-    setIsLoading(true); 
     if (selectedCategory === 'all') {
-      return allThemes;
+      return themes;
     }
-    return allThemes.filter(theme => theme.category === selectedCategory);
-  }, [allThemes, selectedCategory]);
-
-  // Simulate loading
-  useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 300); // Short delay to show loading state
-    return () => clearTimeout(timer);
-  }, [selectedCategory]);
+    return themes.filter(theme => theme.category === selectedCategory);
+  }, [themes, selectedCategory]);
 
 
   const handleSelectCategory = (category: ThemeCategory) => {
@@ -41,7 +33,7 @@ const ThemesPage: React.FC = () => {
           onSelectCategory={handleSelectCategory}
         />
         <div className="container mx-auto max-w-screen-xl">
-          <ThemeGridArea themes={filteredThemes} isLoading={isLoading} />
+          <ThemeGridArea themes={filteredThemes} isLoading={loading} />
         </div>
       </main>
       <Footer variant="main" />


### PR DESCRIPTION
## Summary
- fetch themes with `useThemes` in themes pages and sections
- pull books via `useBooks` for recommendations and search
- get theme options from API instead of mocks for filters

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: TEST_DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68416a081658832e97789882114bc0f7