### PR TITLE
Fix child info registration

### DIFF
--- a/backend/app/crud/crud_user.py
+++ b/backend/app/crud/crud_user.py
@@ -46,6 +46,17 @@ def create_user(db: Session, user: schemas.UserCreate) -> models.User:
     db.flush()  # Flush to get db_user.id
     db.refresh(db_user)
 
+    # Create children if provided
+    if user.children:
+        for child_in in user.children:
+            db_child = models.Child(
+                **child_in.model_dump(),
+                user_id=db_user.id,
+            )
+            db.add(db_child)
+            db.flush()
+            db.refresh(db_child)
+
     # Create default user settings
     db_user_settings = models.UserSettings(user_id=db_user.id)
     db.add(db_user_settings)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -85,6 +85,7 @@ class UserBase(BaseModel):
 class UserCreate(UserBase):
     password: str = Field(..., min_length=8, json_schema_extra={
                           "example": "securepassword123"})
+    children: Optional[List["ChildCreate"]] = None
 
 
 class UserUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- extend `UserCreate` schema to accept optional children
- create child records when registering a new user
- cover registration with children in CRUD and API tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417bb2cbb4832ea08f1f8223142ce1